### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,18 +1,18 @@
 # Animation::Step Class
 Step	KEYWORD3
 Pin	KEYWORD1
-State   KEYWORD1
+State	KEYWORD1
 Duration	KEYWORD1
 
 # Animation::Script Class
 Script	KEYWORD3
 Spin	KEYWORD2
 Stop	KEYWORD2
-ID KEYWORD2
+ID	KEYWORD2
 
 # Animation::Animator Class
-Animator    KEYWORD3
-Spin
-AddScript
-StopScript
-StopAllScripts
+Animator	KEYWORD3
+Spin	KEYWORD3
+AddScript	KEYWORD3
+StopScript	KEYWORD3
+StopAllScripts	KEYWORD3


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords